### PR TITLE
Update wait-for-it.sh to be Alpine friendly

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-#   Use this script to test if a given TCP host/port are available
-#   Fork from https://github.com/vishnubob/wait-for-it
+# Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}
 
@@ -37,7 +36,7 @@ wait_for()
             nc -z $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
-            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
             WAITFORIT_result=$?
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then
@@ -142,16 +141,20 @@ WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
 WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
 WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
 
-# check to see if timeout is from busybox?
+# Check to see if timeout is from busybox?
 WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
 WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
-if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
-        WAITFORIT_ISBUSY=1
-        WAITFORIT_BUSYTIMEFLAG="-t"
 
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
 else
-        WAITFORIT_ISBUSY=0
-        WAITFORIT_BUSYTIMEFLAG=""
+    WAITFORIT_ISBUSY=0
 fi
 
 if [[ $WAITFORIT_CHILD -gt 0 ]]; then


### PR DESCRIPTION
This PR is intended to address #12, as the current version of PHP (7.2) with the `latest` Docker tag has issues with specific versions of MariaDB.

If a user attempts to build the `Dockerfile` as it currently stands without the updates to `wait-for-it.sh` the Docker entrypoint will fail due to the BusyBox version of timeout per the error in the issue.

These updates will cover the Alpine/BusyBox version of timeout and will hopefully also result in another `latest` tag being built and pushed to DockerHub.

Fixes #12.